### PR TITLE
fix!: use arrays for collections instead of sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const client = new RemotePinningServiceClient(config)
   // Get 10 failed Pins
   const pinsGetOptions: PinsGetRequest = {
     limit: 10,
-    status: new Set([Status.Failed]) // requires a set, and not an array
+    status: [Status.Failed]
   }
   const {count, results}: PinResults = await client.pinsGet(pinsGetOptions)
 
@@ -52,6 +52,8 @@ npm run build
 ### Updating the generated client
 
 To update the client, you need to `npm run gen` npm script. This will fetch the latest version of the OpenAPI spec and generate the client. However, openapi-generator-cli does not currently generate the client code with proper import syntax. So you must modify the imports in `generated/fetch/**` directly, or just `git checkout -p` to remove the invalid import path changes.
+
+It also uses `Set`s for all collection types though it cannot serialize or deserialize these types to/from JSON. They must be manually changed to be `Array`s.
 
 If you need to modify the generated code's import paths, you will have to run `npm run postgen` manually.
 

--- a/generated/fetch/src/apis/PinsApi.ts
+++ b/generated/fetch/src/apis/PinsApi.ts
@@ -36,10 +36,10 @@ import {
 } from '../models/index.js';
 
 export interface PinsGetRequest {
-    cid?: Set<string>;
+    cid?: Array<string>;
     name?: string;
     match?: TextMatchingStrategy;
-    status?: Set<Status>;
+    status?: Array<Status>;
     before?: Date;
     after?: Date;
     limit?: number;
@@ -73,10 +73,10 @@ export interface PinsApiInterface {
     /**
      * List all the pin objects, matching optional filters; when no filter is provided, only successful pins are returned
      * @summary List pin objects
-     * @param {Set<string>} [cid] Return pin objects responsible for pinning the specified CID(s); be aware that using longer hash functions introduces further constraints on the number of CIDs that will fit under the limit of 2000 characters per URL  in browser contexts
+     * @param {Array<string>} [cid] Return pin objects responsible for pinning the specified CID(s); be aware that using longer hash functions introduces further constraints on the number of CIDs that will fit under the limit of 2000 characters per URL  in browser contexts
      * @param {string} [name] Return pin objects with specified name (by default a case-sensitive, exact match)
      * @param {TextMatchingStrategy} [match] Customize the text matching strategy applied when name filter is present
-     * @param {Set<Status>} [status] Return pin objects for pins with the specified status
+     * @param {Array<Status>} [status] Return pin objects for pins with the specified status
      * @param {Date} [before] Return results created (queued) before provided timestamp
      * @param {Date} [after] Return results created (queued) after provided timestamp
      * @param {number} [limit] Max records to return
@@ -173,7 +173,7 @@ export class PinsApi extends runtime.BaseAPI implements PinsApiInterface {
         const queryParameters: any = {};
 
         if (requestParameters.cid) {
-            queryParameters['cid'] = Array.from(requestParameters.cid).join(runtime.COLLECTION_FORMATS["csv"]);
+            queryParameters['cid'] = requestParameters.cid.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
         if (requestParameters.name !== undefined) {
@@ -185,7 +185,7 @@ export class PinsApi extends runtime.BaseAPI implements PinsApiInterface {
         }
 
         if (requestParameters.status) {
-            queryParameters['status'] = Array.from(requestParameters.status).join(runtime.COLLECTION_FORMATS["csv"]);
+            queryParameters['status'] = requestParameters.status.join(runtime.COLLECTION_FORMATS["csv"]);
         }
 
         if (requestParameters.before !== undefined) {

--- a/generated/fetch/src/models/Pin.ts
+++ b/generated/fetch/src/models/Pin.ts
@@ -33,10 +33,10 @@ export interface Pin {
     name?: string;
     /**
      * Optional list of multiaddrs known to provide the data
-     * @type {Set<string>}
+     * @type {Array<string>}
      * @memberof Pin
      */
-    origins?: Set<string>;
+    origins?: Array<string>;
     /**
      * Optional metadata for pin object
      * @type {{ [key: string]: string; }}

--- a/generated/fetch/src/models/PinResults.ts
+++ b/generated/fetch/src/models/PinResults.ts
@@ -34,10 +34,10 @@ export interface PinResults {
     count: number;
     /**
      * An array of PinStatus results
-     * @type {Set<PinStatus>}
+     * @type {Array<PinStatus>}
      * @memberof PinResults
      */
-    results: Set<PinStatus>;
+    results: Array<PinStatus>;
 }
 
 export function PinResultsFromJSON(json: any): PinResults {
@@ -51,7 +51,7 @@ export function PinResultsFromJSONTyped(json: any, ignoreDiscriminator: boolean)
     return {
         
         'count': json['count'],
-        'results': (new Set((json['results'] as Array<any>).map(PinStatusFromJSON))),
+        'results': ((json['results'] as Array<any>).map(PinStatusFromJSON)),
     };
 }
 
@@ -65,7 +65,7 @@ export function PinResultsToJSON(value?: PinResults | null): any {
     return {
         
         'count': value.count,
-        'results': (Array.from(value.results as Set<any>).map(PinStatusToJSON)),
+        'results': ((value.results as Array<any>).map(PinStatusToJSON)),
     };
 }
 

--- a/generated/fetch/src/models/PinStatus.ts
+++ b/generated/fetch/src/models/PinStatus.ts
@@ -58,10 +58,10 @@ export interface PinStatus {
     pin: Pin;
     /**
      * List of multiaddrs designated by pinning service for transferring any new data from external peers
-     * @type {Set<string>}
+     * @type {Array<string>}
      * @memberof PinStatus
      */
-    delegates: Set<string>;
+    delegates: Array<string>;
     /**
      * Optional info for PinStatus response
      * @type {{ [key: string]: string; }}

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -38,8 +38,8 @@ describe('Client', () => {
 
     it('GET: Can get failed Pins', async () => {
       const Client = new RemotePinningServiceClient(Config)
-      const response = await Client.pinsGet({ limit: 1, status: new Set([Status.Failed]) })
-      expect(response).to.deep.eq({ count: 0, results: new Set() })
+      const response = await Client.pinsGet({ limit: 1, status: [Status.Failed] })
+      expect(response).to.deep.eq({ count: 0, results: [] })
     })
 
     it('GET: Can add a Pin successfully', async () => {


### PR DESCRIPTION
Because we have `uniqueItems: true` in our service definition yaml, fields with `type: array` are generated as `Set`s by the typescript generator.

Serialization/deserialization of these types is [broken](https://github.com/OpenAPITools/openapi-generator/issues/11746) so where we use these APIs [we pass arrays with `@ts-expect-error` anyway](https://github.com/ipfs/helia-remote-pinning/blob/916ffdc3d6956ad9958cfc0ed800b2a337a733f3/src/heliaRemotePinner.ts#L154-L155).

It also makes pagination harder to use, since we need to set the `.after` field to get the next page of pins - sets have no guarantee of order so you have to first convert the current set of results into an array and sort it by creation date which is inefficient.

It doesn't look possible to override the use of Set by the generator in a way that works (`type-mappings=set=array` produces uncompilable code) so manually change the generated code in the same way we have to change the import settings (due, I think, to [another option that doesn't work](https://github.com/OpenAPITools/openapi-generator/pull/15440)).

Also adds a note to the readme reminding people to do it.

BREAKING CHANGE: fields that were `Set`s such as `PinResults.results` and `PinsGetRequest.cid` are now `Array`s